### PR TITLE
Add env example and contributing section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=https://openapi.jieshuo.cn

--- a/README.en.md
+++ b/README.en.md
@@ -95,7 +95,14 @@
    npm install
    ```
 
-3. **Start the demo interface:**
+3. **Copy the environment file:**
+
+   ```bash
+   cp .env.example .env.local
+   # Edit NEXT_PUBLIC_API_BASE_URL if needed
+   ```
+
+4. **Start the demo interface:**
 
    ```bash
    npm run dev
@@ -211,6 +218,12 @@
 * [x] Subtitle removal frontend interface
 * [x] Video embedding frontend interface
 * [x] AI narration interactive interface
+
+## 🤝 Contributing
+
+1. Fork this repository and create a feature branch.
+2. Run `npm run lint` before opening a PR to keep code style consistent.
+3. Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 
 ## 🔐 License
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,13 @@
    npm install
    ```
 
-3. **启动演示界面:**
+3. **复制环境配置文件:**
 
+   ```bash
+   cp .env.example .env.local
+   # 根据需要修改 NEXT_PUBLIC_API_BASE_URL
+   ```
+4. **启动演示界面:**
    ```bash
    npm run dev
    ```
@@ -213,6 +218,12 @@
 * [x] 字幕擦除前端界面
 * [x] 视频压制前端界面
 * [x] AI 解说交互界面
+
+## 🤝 贡献指南
+
+1. Fork 本仓库并创建分支。
+2. 提交 PR 前请运行 `npm run lint` 保持代码风格一致。
+3. 提交信息请遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/) 规范。
 
 ## 🔐 许可说明
 


### PR DESCRIPTION
## Summary
- document environment configuration in Quick Start
- include `.env.example`
- add Contributing guidelines in README and README.en

## Testing
- `npm run lint` *(fails: next not found)*